### PR TITLE
chore(workflow): change renovate rangeStrategy for groups

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,13 +14,11 @@
   "packageRules": [
     {
       "groupName": "devDependencies",
-      "matchDepTypes": ["devDependencies"],
-      "rangeStrategy": "bump"
+      "matchDepTypes": ["devDependencies"]
     },
     {
       "groupName": "dependencies",
-      "matchDepTypes": ["dependencies"],
-      "rangeStrategy": "replace"
+      "matchDepTypes": ["dependencies"]
     },
     {
       "groupName": "eslint",


### PR DESCRIPTION
## Description

Change "rangeStrategy" in the renovate config to use the global "bump" strategy for all package groups.